### PR TITLE
Resolve Windows issue not finding installed library in userspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,23 @@ Blender 2.8x add-on that allows streaming of data (from another computer) into B
 **without** freezing the interface (publisher-subscriber pattern).
 
 ## Update
+- v1.2.1 (2022-11-13) - Fixed Python libraries (`pyzmq`) not findable when installed in userspace
+    - On **Windows**, pip installed libraries might be installed outside the Blender dir.
+      When failing to import a library, an extra import attempt adds `site.getusersitepackages()` to `sys.path`.
+        - Blender on Windows might be installed under: `C:\Program Files\Blender Foundation\Blender 3.3\3.3\python\bin\python.EXE`.
+          However, even when referring to this binary, libraries might still be installed under e.g.
+          `C:\users\{user}\appdata\roaming\python\python310\site-packages`
 - v1.2 (2022-11-01) - Now supports **Blender version 2.93 LTS and 3.3 LTS**! Changes:
     - No Blender restart required anymore
     - Python binary has to be accessed from `sys.executable` from v2.93 (rather than `bpy.app.binary_path_python`)
     - Slightly refracted code in `PIPZMQ_OT_pip_pyzmq`
     - Blender < 2.93 functioning unchanged
     - Test scripts moved under `utils/`
-- v1.1 (2020-02-10)
-    - **Blender 2.81+ pip support**: In Blender 2.81 pip is enabled by default.
-This update takes that behavior into account. If the `Enable pip & install pyzmq` button fails, it still executes
-`ensurepip.bootstrap()`. Restart Blender and try again, it will work this time
-(on Windows make sure you run with admin rights).
+- v1.1 (2020-02-10) - **Blender 2.81+ pip support**. Changes:
+    - In Blender 2.81 pip is enabled by default. This update takes that behavior into account.
+        - If the `Enable pip & install pyzmq` button fails, it still executes
+        `ensurepip.bootstrap()`. Restart Blender and try again, it will work this time
+        (on Windows make sure you run with admin rights).
 
 ## Overview
 Blender is very powerful software, but if you run your own code that's a bit heavy, you quickly make the interface
@@ -45,7 +51,7 @@ for programs outside Blender.
      1. Anaconda 3.10+: https://www.anaconda.com/distribution/
      2. `conda create --name bzmq python=3.10`  # create environment with Python 3.7
      3. `conda activate bzmq`  # activate newly created environment
-     4. `conda install -c anaconda pyzmq=24.0`  # install pyzmq in this environment
+     4. `conda install -c conda-forge pyzmq=24.0`  # install pyzmq in this environment
    - System Python: `pip install pyzmq=24.0.*`
 
 ## How to use

--- a/blendzmq_panel.py
+++ b/blendzmq_panel.py
@@ -18,6 +18,9 @@
 
 # Copyright (c) Stef van der Struijk <stefstruijk@protonmail.ch>
 
+import os
+import sys
+import site
 import bpy
 from bpy.types import Panel
 
@@ -42,7 +45,15 @@ class BLENDZMQ_PT_zmqConnector(Panel):
         #   check if pyzmq is installed; will fail with an ImportError if not
         # if installed, will show interaction options: (dis)connect socket and whether to use dynamic object selection
         try:
-            import zmq
+            # attempt 1: installed and on Python sys path
+            try:
+                import zmq
+            # attempt 2: maybe installed, but not yet in sys path (Windows)
+            except ImportError:
+                user_site_packages = site.getusersitepackages()
+                if os.path.exists(user_site_packages) and user_site_packages not in sys.path:
+                    sys.path.append(user_site_packages)
+                import zmq
 
             # connection information
             row = layout.row()


### PR DESCRIPTION
Even though installing of `pyzmq` goes fine. Blender still couldn't import the library. Turned out the library was installed in user space: `C:\users\{user}\appdata\roaming\python\python310\site-packages` rather than Blender's folder (`C:\Program Files\Blender Foundation\Blender 3.3\3.3\python\bin\python.EXE`)

Helpful discussion: https://developer.blender.org/T76993